### PR TITLE
add Node.Name() to expose the xml.Name of a node

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -164,6 +164,10 @@ func (node *Node) contains(s string) (ok bool) {
 	return false
 }
 
+func (n *Node) Name() xml.Name {
+	return n.name
+}
+
 // Parse reads an xml document from r, parses it, and returns its root node.
 func Parse(r io.Reader) (*Node, error) {
 	return ParseDecoder(xml.NewDecoder(r))


### PR DESCRIPTION
was very useful for a project of mine where I was parsing a partially dynamic schema 